### PR TITLE
Dockerfile: download release binaries.

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,22 +4,20 @@
 
 FROM mcr.microsoft.com/vscode/devcontainers/universal:linux as builder
 USER root
-
-# Magic DNS in a container where /etc/resolv.conf is a bind mount needed
-# extra support, currently on a development branch.
-WORKDIR /go/src/tailscale
+WORKDIR /app
 COPY . ./
-RUN git clone https://github.com/tailscale/tailscale.git && cd tailscale && \
-    go mod download && \
-    go install -mod=readonly ./cmd/tailscaled ./cmd/tailscale
+ENV TSFILE=tailscale_1.26.1_amd64.tgz
+RUN mkdir -p binaries && \
+  wget https://pkgs.tailscale.com/stable/${TSFILE} && \
+  tar xzf ${TSFILE} --strip-components=1 -C binaries
 COPY . ./
 
 FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
 USER root
 
 RUN apt-get update && apt-get install -y curl gpg dnsutils
-COPY tailscaled /etc/init.d
-COPY --from=builder /go/bin/tailscaled /usr/sbin/tailscaled
-COPY --from=builder /go/bin/tailscale /usr/bin/tailscale
+COPY tailscaled /etc/init.d/tailscaled
+COPY --from=builder /app/binaries/tailscaled /usr/sbin/tailscaled
+COPY --from=builder /app/binaries/tailscale /usr/bin/tailscale
 
 RUN mkdir -p /var/run/tailscale /var/cache/tailscale /var/lib/tailscale


### PR DESCRIPTION
The support implemented for codespaces merged into
releases long ago.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>