### PR TITLE
ensure that tailscaled is executable

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -17,6 +17,7 @@ USER root
 
 RUN apt-get update && apt-get install -y curl gpg dnsutils
 COPY tailscaled /etc/init.d/tailscaled
+RUN chmod +x /etc/init.d/tailscaled
 COPY --from=builder /app/binaries/tailscaled /usr/sbin/tailscaled
 COPY --from=builder /app/binaries/tailscale /usr/bin/tailscale
 


### PR DESCRIPTION
If someone is copying the examples here to their own repo, they may forget to make the `tailscaled` file executable when they create it in their local repo.  Just in case that happens we can make sure that the `tailscaled` is executable when we copy it into the image.