### PR TITLE
remove base-path-to-features

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,7 +11,6 @@ jobs:
         uses: devcontainers/action@v1
         with:
           publish-features: "true"
-          base-path-to-features: "./tailscale"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:


### PR DESCRIPTION
Definitely not the right thing to do:

ERR: devcontainer-feature.json not found at path
'tailscale/devcontainer-feature.json/devcontainer-feature.json'.

Signed-off-by: Denton Gentry <dgentry@tailscale.com>