### PR TITLE
Add an option to register DevContainers nodes as ephemeral

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -12,6 +12,11 @@
       "type": "string",
       "default": "1.34.1",
       "description": "Version of Tailscale to download"
+    },
+    "ephemeral": {
+      "type": "boolean",
+      "default": false,
+      "description": "Register the container as an Tailscale ephemeral node"
     }
   }
 }

--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -16,7 +16,7 @@
     "ephemeral": {
       "type": "boolean",
       "default": false,
-      "description": "Register the container as an Tailscale ephemeral node"
+      "description": "Register the container as a Tailscale ephemeral node"
     }
   }
 }

--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -5,18 +5,24 @@
 
 set -euxo pipefail
 
+if [[ "$EPHEMERAL" == "true" ]]; then
+  TAILSCALE_STATE="--state=mem:"
+else
+  TAILSCALE_STATE="--statedir=/workspaces/.tailscale/"
+fi
+
 if [[ "$(id -u)" -eq 0 ]]; then
   mkdir -p /workspaces/.tailscale || true
   /usr/local/sbin/tailscaled \
-    --state=mem: \
+    $TAILSCALE_STATE \
     --socket=/var/run/tailscale/tailscaled.sock \
     --port=41641 \
     >& /dev/null &
 elif command -v sudo >& /dev/null; then
-  sudo --non-interactive sh -c 'mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
-    --state=mem: \
+  sudo --non-interactive sh -c "mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
+    $TAILSCALE_STATE \
     --socket=/var/run/tailscale/tailscaled.sock \
-    --port=41641 >& /dev/null' &
+    --port=41641 >& /dev/null" &
 else
   echo "tailscaled could not start as root." 1>&2
 fi

--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -8,13 +8,13 @@ set -euxo pipefail
 if [[ "$(id -u)" -eq 0 ]]; then
   mkdir -p /workspaces/.tailscale || true
   /usr/local/sbin/tailscaled \
-    --statedir=/workspaces/.tailscale/ \
+    --state=mem: \
     --socket=/var/run/tailscale/tailscaled.sock \
     --port=41641 \
     >& /dev/null &
 elif command -v sudo >& /dev/null; then
   sudo --non-interactive sh -c 'mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
-    --statedir=/workspaces/.tailscale/ \
+    --state=mem: \
     --socket=/var/run/tailscale/tailscaled.sock \
     --port=41641 >& /dev/null' &
 else


### PR DESCRIPTION
GitHub Codespaces and other Dev Containers environments are usually driven by short-term lives, i.e., activity expirations and persistency expiration.
Thus, it appears to be relevant to register every new dev container as an ephemeral node, and enforce security measures at next boot up/recreation.