### PR TITLE
Move devcontainer to tailscale/codespace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,6 +12,7 @@ jobs:
         with:
           publish-features: "true"
           base-path-to-features: "./src"
+          features-namespace: "tailscale/codespace"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to your `devcontainer.json`:
 "runArgs": ["--device=/dev/net/tun"],
 "features": {
   // ...
-  "ghcr.io/tailscale/codespace/tailscale": {}
+  "ghcr.io/tailscale/codespace": {}
   // ...
 }
 ```


### PR DESCRIPTION
Currently the container appears at:
https://github.com/tailscale/codespace/pkgs/container/codespace%2Ftailscale

Move it to:
https://github.com/tailscale/codespace/pkgs/container/codespace