### PR TITLE
Increment semver for new namespace.

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Tailscale",
   "id": "tailscale",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Connect to your tailnet in your development container",
   "documentationURL": "https://tailscale.com/kb/1160/github-codespaces/",
   "licenseURL": "https://github.com/tailscale/codespace/blob/main/LICENSE",


### PR DESCRIPTION
I thought that changing the namespace meant it wouldn't find 1.0.1 and would publish it to the new location, but no.