### PR TITLE
update templates-namespace

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,7 @@ jobs:
           publish-features: "true"
           base-path-to-features: "./src"
           features-namespace: "tailscale/codespace"
+          templates-namespace: "tailscale/codespace"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 permissions:

--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Tailscale",
   "id": "tailscale",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Connect to your tailnet in your development container",
   "documentationURL": "https://tailscale.com/kb/1160/github-codespaces/",
   "licenseURL": "https://github.com/tailscale/codespace/blob/main/LICENSE",


### PR DESCRIPTION
The 1.0.2 version went to both the original namespace https://github.com/tailscale/codespace/pkgs/container/codespace%2Ftailscale

and to the new, and intended, namespace:
https://github.com/tailscale/codespace/pkgs/container/codespace

Most importantly, the 1.0.2 tag only appears in the original namespace, and we want it to appear in the new namespace.

Add a templates-namespace declaration, maybe the original namespace is being used because of the template.