### PR TITLE
Fix feature path

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ to your `devcontainer.json`:
 "runArgs": ["--device=/dev/net/tun"],
 "features": {
   // ...
-  "ghcr.io/tailscale/codespace": {}
+  "ghcr.io/tailscale/codespace/tailscale:1": {}
   // ...
 }
 ```


### PR DESCRIPTION
The `/tailscale` path suffix is required as it is mapped to the `./src` directory in this repo.

Added `:1` to pin the major version.