### PR TITLE
Update scripts to be compatible with `sh`

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Tailscale",
   "id": "tailscale",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Connect to your tailnet in your development container",
   "documentationURL": "https://tailscale.com/kb/1160/github-codespaces/",
   "licenseURL": "https://github.com/tailscale/codespace/blob/main/LICENSE",

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -8,12 +8,12 @@ set -euo pipefail
 tailscale_url="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
 
 download() {
-  if command -v curl >& /dev/null; then
+  if command -v curl &> /dev/null; then
     curl -fsSL "$1"
-  elif command -v wget >& /dev/null; then
+  elif command -v wget &> /dev/null; then
     wget -qO - "$1"
   else
-    echo "Must install curl or wget to download $1" 1>&2
+    echo "Must install curl or wget to download $1" 1&>2
     return 1
   fi
 }

--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -11,14 +11,14 @@ if [[ "$(id -u)" -eq 0 ]]; then
     --statedir=/workspaces/.tailscale/ \
     --socket=/var/run/tailscale/tailscaled.sock \
     --port=41641 \
-    >& /dev/null &
-elif command -v sudo >& /dev/null; then
+    &> /dev/null &
+elif command -v sudo &> /dev/null; then
   sudo --non-interactive sh -c 'mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
     --statedir=/workspaces/.tailscale/ \
     --socket=/var/run/tailscale/tailscaled.sock \
-    --port=41641 >& /dev/null' &
+    --port=41641 &> /dev/null' &
 else
-  echo "tailscaled could not start as root." 1>&2
+  echo "tailscaled could not start as root." 1&>2
 fi
 
 exec "$@"


### PR DESCRIPTION
The usage of `>&` redirection operators in the install and entrypoint scripts causes the scripts to fail when run under the default shell, (when not bash). Usage of `&>` is preferred.