### PR TITLE
tailscaled-entrypoint: use sh compatible syntax for redirecting output

### DIFF
--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -11,12 +11,12 @@ if [[ "$(id -u)" -eq 0 ]]; then
     --statedir=/workspaces/.tailscale/ \
     --socket=/var/run/tailscale/tailscaled.sock \
     --port=41641 \
-    >& /dev/null &
+    >/dev/null 2>&1 &
 elif command -v sudo >& /dev/null; then
   sudo --non-interactive sh -c 'mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
     --statedir=/workspaces/.tailscale/ \
     --socket=/var/run/tailscale/tailscaled.sock \
-    --port=41641 >& /dev/null' &
+    --port=41641 >/dev/null 2>&1' &
 else
   echo "tailscaled could not start as root." 1>&2
 fi


### PR DESCRIPTION
When running as a non-root user the command is run under `sh` and so should use less fancy methods of redirecting output.

This results in codespaces running as non-root users failing to start tailscaled at startup:

```console
@rhettg ➜ /workspaces/mcc (rhettg-configure-tailscale) $ sudo tailscale up --accept-routes
failed to connect to local tailscaled; it doesn't appear to be running (sudo systemctl start tailscaled ?)
@rhettg ➜ /workspaces/mcc (rhettg-configure-tailscale) $ ps aux | grep tailscaled
codespa+       1  0.0  0.0   1136     4 ?        Ss   17:53   0:00 /sbin/docker-init -- /bin/sh -c echo Container started trap "exit 0" 15 /usr/local/share/ssh-init.sh /usr/local/share/docker-init.sh /usr/local/sbin/tailscaled-entrypoint exec "$@" while sleep 1 & wait $!; do :; done - /usr/local/share/docker-init.sh /usr/local/share/ssh-init.sh sleep infinity
codespa+   20252  0.0  0.0   8172  2508 pts/3    S+   18:04   0:00 grep --color=auto tailscaled
@rhettg ➜ /workspaces/mcc (rhettg-configure-tailscale) $ /usr/local/sbin/tailscaled-entrypoint
++ id -u
+ [[ 1000 -eq 0 ]]
+ command -v sudo
+ exec
+ sudo --non-interactive sh -c 'mkdir -p /workspaces/.tailscale ; /usr/local/sbin/tailscaled \
    --statedir=/workspaces/.tailscale/ \
    --socket=/var/run/tailscale/tailscaled.sock \
    --port=41641 >& /dev/null'
sh: 4: Syntax error: Bad fd number
```

This is a minimal/less complete version of https://github.com/tailscale/codespace/pull/22 which solved my immediate problem of the feature not running `tailscaled` at startup.

I will not be offended by closing this in preference to #22 or any other approach that solves this in upstream without my name on it.