### PR TITLE
Set the default Tailscale version to `latest`

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -10,7 +10,7 @@
   "options": {
     "version": {
       "type": "string",
-      "default": "1.36.2",
+      "default": "latest",
       "description": "Version of Tailscale to download"
     }
   }


### PR DESCRIPTION
It’s standard practice among devcontainers features to leave the default version of a package (such as tailscale) unpinned, so that installing the feature always provides the latest version. Users who need more stability are encouraged to pin the version themselves in their `devcontainer.json` (which they can currently do with the `version` option in this package). This also means less lift for maintainers, who don’t have to release updates to the devcontainer feature every time the downstream dependencies get a bump. This PR proposes that this package does the same, so that users get the latest features by default.

I checked, and `https://pkgs.tailscale.com/stable/tailscale_latest_amd64.tgz` helpfully resolves to the tarball of the latest version.

But if that’s not aligned with how Tailscale want to operate this package, then happy to just set `{ version: “latest” }` on my own `devcontainer` ^_^