### PR TITLE
Platform Support - added arm64

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Tailscale",
   "id": "tailscale",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Connect to your tailnet in your development container",
   "documentationURL": "https://tailscale.com/kb/1160/github-codespaces/",
   "licenseURL": "https://github.com/tailscale/codespace/blob/main/LICENSE",

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -5,7 +5,15 @@
 
 set -euo pipefail
 
-tailscale_url="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
+platform=$(uname -m)
+if [ "$platform" = "x86_64" ]; then
+    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_amd64.tgz"
+elif [ "$platform" = "aarch64" ]; then
+    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_arm64.tgz"
+else
+    echo "Unsupported platform: $platform"
+    exit 1
+fi
 
 download() {
   if command -v curl &> /dev/null; then

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -8,7 +8,7 @@ set -euo pipefail
 platform=$(uname -m)
 if [ "$platform" = "x86_64" ]; then
     tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_amd64.tgz"
-elif [ "$platform" = "aarch64" ]; then
+elif [ "$platform" = "aarch64" ] || [ "$platform" = "arm64" ]; then
     tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_arm64.tgz"
 else
     echo "Unsupported platform: $platform"

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -7,9 +7,9 @@ set -euo pipefail
 
 platform=$(uname -m)
 if [ "$platform" = "x86_64" ]; then
-    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_amd64.tgz"
+    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_amd64.tgz"
 elif [ "$platform" = "aarch64" ] || [ "$platform" = "arm64" ]; then
-    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_1.66.3_arm64.tgz"
+    tailscale_url="https://pkgs.tailscale.com/stable/tailscale_${VERSION}_arm64.tgz"
 else
     echo "Unsupported platform: $platform"
     exit 1


### PR DESCRIPTION
# Description
The tailscale devcontainer feature only supports x86_64 machines due to the hardcoded `tailscale_url`. This PR addresses this issue by dynamically assigning the `tailscale_url` depending on the platform

# Changes
- dynamically assign the `tailscale_url` variable depending on the output of `uname -m`
- bumped version from 1.0.6 to 1.0.7