### PR TITLE
mkdir -p /usr/local/sbin

### DIFF
--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -22,6 +22,7 @@ script_dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 scratch_dir="/tmp/tailscale"
 mkdir -p "$scratch_dir"
 trap 'rm -rf "$scratch_dir"' EXIT
+mkdir -p /usr/local/sbin
 
 download "$tailscale_url" |
   tar -xzf - --strip-components=1 -C "$scratch_dir"


### PR DESCRIPTION
Installation of the devcontainer feature failed because my baseimage had no /usr/local/sbin dir. It is based on alpine. 

https://github.com/SimonHaas/webspace/blob/ae8f32217c349a0aaefc0dd8cc36d728f186bc2b/.devcontainer/Dockerfile#L5