### PR TITLE
install.sh: create parent directories if missing

### DIFF
--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -33,9 +33,9 @@ trap 'rm -rf "$scratch_dir"' EXIT
 
 download "$tailscale_url" |
   tar -xzf - --strip-components=1 -C "$scratch_dir"
-install "$scratch_dir/tailscale" /usr/local/bin/tailscale
-install "$scratch_dir/tailscaled" /usr/local/sbin/tailscaled
-install "$script_dir/tailscaled-entrypoint.sh" /usr/local/sbin/tailscaled-entrypoint
+install -D "$scratch_dir/tailscale" /usr/local/bin/tailscale
+install -D "$scratch_dir/tailscaled" /usr/local/sbin/tailscaled
+install -D "$script_dir/tailscaled-entrypoint.sh" /usr/local/sbin/tailscaled-entrypoint
 
 mkdir -p /var/lib/tailscale /var/run/tailscale
 


### PR DESCRIPTION
An example is using an Alpine base container, there would be no /usr/local/sbin directory and the install command would fail.

Fixes #41