### PR TITLE
tailscale: persist state across container restarts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ sudo tailscale up --accept-routes
 You'll only need to run `tailscale up` once per Codespace.
 The Tailscale state will be saved between rebuilds.
 
+## Details
+
+- A mount is added called `tailscale-${devcontainerId}` mapped to
+  `/var/lib/tailscale` to persist taislcaled state across devcontainer rebuilds,
+  so a single devcontainer will remain logged in for the devcontainer lifetime.
+- The feature requires `CAP_NET_ADMIN` in order to configure certain network
+  properties for kernel mode tailscale.
+- The feature requires kernel tun support in the runtime and `CAP_MKNOD` so that
+  it can create a tun device node if needed.
+- `CAP_NET_RAW` enables the feature to send ICMP.
+
 ## Development
 
 A convenient way to develop this feature is to use codespaces, as they start by

--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -13,5 +13,12 @@
       "default": "latest",
       "description": "Version of Tailscale to download"
     }
-  }
+  },
+  "mounts": [
+    {
+      "source": "tailscale-${devcontainerId}",
+      "target": "/var/lib/tailscale",
+      "type": "volume"
+    }
+  ]
 }

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -64,7 +64,8 @@ install -D "$scratch_dir/tailscale" /usr/local/bin/tailscale
 install -D "$scratch_dir/tailscaled" /usr/local/sbin/tailscaled
 install -D "$script_dir/tailscaled-entrypoint.sh" /usr/local/sbin/tailscaled-entrypoint
 
-mkdir -p /var/lib/tailscale /var/run/tailscale
+mkdir -p /var/lib/tailscale /var/run/tailscale /var/log
+touch /var/log/tailscaled.log
 
 if ! command -v iptables >& /dev/null; then
   if command -v apt-get >& /dev/null; then

--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -30,13 +30,7 @@ if [[ "$(id -u)" -eq 0 ]]; then
     mknod /dev/net/tun c 10 200
   fi
   check_userspace
-  mkdir -p /workspaces/.tailscale /var/log
-  touch $TAILSCALED_LOG
-  >$TAILSCALED_LOG 2>&1 \
-    /usr/local/sbin/tailscaled \
-    --statedir=/workspaces/.tailscale/ \
-    --socket=$TAILSCALED_SOCK \
-    --port=41641 &
+  >$TAILSCALED_LOG 2>&1 /usr/local/sbin/tailscaled &
   TAILSCALED_PID=$!
 elif command -v sudo > /dev/null; then
   if [[ ! -c /dev/net/tun ]]; then
@@ -44,14 +38,9 @@ elif command -v sudo > /dev/null; then
     sudo --non-interactive mknod /dev/net/tun c 10 200
   fi
   check_userspace
-  sudo --non-interactive mkdir -p /workspaces/.tailscale /var/log
-  sudo --non-interactive touch $TAILSCALED_LOG
   >$TAILSCALED_LOG 2>&1 \
     sudo --non-interactive "TS_DEBUG_FIREWALL_MODE=$TS_DEBUG_FIREWALL_MODE" \
-    /usr/local/sbin/tailscaled \
-    --statedir=/workspaces/.tailscale/ \
-    --socket=$TAILSCALED_SOCK \
-    --port=41641 &
+    /usr/local/sbin/tailscaled &
   TAILSCALED_PID=$!
 else
   >&2 echo "tailscaled could not start as root."


### PR DESCRIPTION
The state directory is now in the default location inside the container,
/var/lib/tailscale and other default parameters for tailscaled are
removed. The state directory is now a mount declared in the feature
specification, and references `${devcontainerId}` so that the state is
local to the particular devcontainer instance.

Updates #40