### PR TITLE
tailscale: add support for auth key secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,14 +16,29 @@ to your `devcontainer.json`:
 }
 ```
 
-Then launch your Codespace. After it starts up, run [`tailscale up`](https://tailscale.com/kb/1080/cli/#up):
+## Starting Tailscale
+
+The Tailscale daemon starts automatically as part of the devcontainer entrypoint.
+
+### Manual Log in
 
 ```shell
 sudo tailscale up --accept-routes
 ```
 
-You'll only need to run `tailscale up` once per Codespace.
-The Tailscale state will be saved between rebuilds.
+More info: [`tailscale up`](https://tailscale.com/kb/1080/cli/#up)
+
+### Automatic login
+
+Create an [auth key](https://tailscale.com/kb/1085/auth-keys) in the Tailscale
+[admin panel](https://login.tailscale.com/admin/settings/keys).
+
+Create a codespace secret called `TS_AUTH_KEY` in your
+[codespaces configuration](https://github.com/settings/codespaces) containing
+the auth key you made above.
+
+Now whenever you launch a devcontainer with access to this secret, it will
+automatically perform a `tailscale up --accept-routes --auth-key=$TS_AUTH_KEY`.
 
 ## Details
 

--- a/src/tailscale/tailscaled-entrypoint.sh
+++ b/src/tailscale/tailscaled-entrypoint.sh
@@ -5,4 +5,6 @@
 
 /usr/local/sbin/tailscaled-devcontainer-start
 
+unset TS_AUTH_KEY
+
 exec "$@"

--- a/test/tailscale/scenarios.json
+++ b/test/tailscale/scenarios.json
@@ -18,5 +18,14 @@
                 "version": "1.80.2"
             }
         }
+    },
+    "tailscale_auth_key": {
+        "image": "ubuntu:latest",
+        "containerEnv": {
+            "TS_AUTH_KEY": "test-auth-key"
+        },
+        "features": {
+            "tailscale": {}
+        }
     }
 }

--- a/test/tailscale/tailscale_auth_key.sh
+++ b/test/tailscale/tailscale_auth_key.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+set -e
+
+source dev-container-features-test-lib
+
+# Wait for the auth key to be seen by the start script.
+count=100
+while ((count--)); do
+    [[ -f /tmp/test-auth-key-seen ]] && break
+    sleep 0.1
+done
+
+check "/tmp/test-auth-key-seen" ls /tmp/test-auth-key-seen
+
+# It would be nice to directly test that the entrypoint is doing unset
+# TS_AUTH_KEY, however that isn't visible to the test execution.
+
+reportResults

--- a/test/tailscale/test.sh
+++ b/test/tailscale/test.sh
@@ -7,10 +7,10 @@ set -e
 
 source dev-container-features-test-lib
 
-if [[ "$VERSION" == latest ]]; then
-    check "Daemon: " tailscale version --daemon
-else
-    check "$VERSION" tailscale version --daemon
+check "daemon is running" tailscale version --daemon
+
+if [[ -n "$VERSION" ]]; then
+    check "version is correct" bash -c "tailscale version --daemon | grep -q $VERSION"
 fi
 
 reportResults


### PR DESCRIPTION
The secrets support here is intended for codespaces where the TS_AUTH_KEY environment variable is protected by github secrets. Setting an auth key via the environment in other devcontainer runtimes may pose additonal security risks associated with secrets in environment variables.