### PR TITLE
split authkey setup script and invoke during poststart

### DIFF
--- a/src/tailscale/devcontainer-feature.json
+++ b/src/tailscale/devcontainer-feature.json
@@ -6,6 +6,7 @@
   "documentationURL": "https://tailscale.com/kb/1160/github-codespaces/",
   "licenseURL": "https://github.com/tailscale/codespace/blob/main/LICENSE",
   "entrypoint": "/usr/local/sbin/tailscaled-entrypoint",
+  "postCreateCommand": "/usr/local/sbin/tailscaled-auth-setup",
   "capAdd": ["NET_ADMIN", "NET_RAW", "MKNOD"],
   "options": {
     "version": {

--- a/src/tailscale/install.sh
+++ b/src/tailscale/install.sh
@@ -67,6 +67,7 @@ install -D -m 755 "$scratch_dir/tailscale" /usr/local/bin/tailscale
 install -D -m 755 "$scratch_dir/tailscaled" /usr/local/sbin/tailscaled
 install -D -m 755 "$script_dir/tailscaled-entrypoint.sh" /usr/local/sbin/tailscaled-entrypoint
 install -D -m 755 "$script_dir/tailscaled-devcontainer-start.sh" /usr/local/sbin/tailscaled-devcontainer-start
+install -D -m 755 "$script_dir/tailscaled-auth-setup.sh" /usr/local/sbin/tailscaled-auth-setup
 
 mkdir -p /var/lib/tailscale /var/run/tailscale /var/log
 touch /var/log/tailscaled.log

--- a/src/tailscale/tailscaled-auth-setup.sh
+++ b/src/tailscale/tailscaled-auth-setup.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Copyright (c) 2025 Tailscale Inc & AUTHORS All rights reserved.
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file.
+
+# This script handles Tailscale authentication during postCreateCommand
+# when GitHub Codespaces secrets are guaranteed to be available
+
+if [[ $(id -u) -ne 0 ]]; then
+  if ! command -v sudo > /dev/null; then
+    >&2 echo "tailscale auth setup could not run as root."
+    exit 1
+  fi
+  exec sudo --non-interactive -E "$0" "$@"
+fi
+
+# Move the auth key to a non-exported variable so it is not leaking into child
+# process environments.
+auth_key="$TS_AUTH_KEY"
+unset TS_AUTH_KEY
+
+TAILSCALED_SOCK=/var/run/tailscale/tailscaled.sock
+
+# Wait for tailscaled to be ready (it should be running from entrypoint)
+count=100
+while ((count--)); do
+  [[ -S $TAILSCALED_SOCK ]] && break
+  sleep 0.1
+  
+  if ((count == 0)); then
+    >&2 echo "ERROR: tailscaled socket not found. Is tailscaled running?"
+    exit 1
+  fi
+done
+
+# Check if already authenticated
+if /usr/local/bin/tailscale status --json >/dev/null 2>&1; then
+  # Already authenticated, check if it's working
+  if /usr/local/bin/tailscale status --json | grep -q '"BackendState":"Running"'; then
+    echo "Tailscale is already running and authenticated"
+    exit 0
+  fi
+fi
+
+# Authenticate with auth key if available
+if [[ -n "$auth_key" ]]; then
+  if [[ "$auth_key" == "test-auth-key" ]]; then
+    # Special test case
+    touch /tmp/test-auth-key-seen
+    echo "Test auth key detected"
+  else
+    echo "Authenticating Tailscale with auth key..."
+    hostnamearg=""
+    if [[ -n "${CODESPACE_NAME}" ]]; then
+      hostnamearg="--hostname=${CODESPACE_NAME}"
+    fi
+    
+    if /usr/local/bin/tailscale up --accept-routes --authkey="$auth_key" $hostnamearg; then
+      echo "Tailscale authentication successful"
+    else
+      >&2 echo "ERROR: Tailscale authentication failed"
+      exit 1
+    fi
+  fi
+else
+  echo "Tailscale is running. To authenticate, run: sudo tailscale up --accept-routes"
+fi

--- a/src/tailscale/tailscaled-devcontainer-start.sh
+++ b/src/tailscale/tailscaled-devcontainer-start.sh
@@ -63,15 +63,3 @@ if [[ -n "$TAILSCALED_PID" ]]; then
     fi
   done
 fi
-
-if [[ -n "$auth_key" ]]; then
-  if [[ "$auth_key" == "test-auth-key" ]]; then
-    touch /tmp/test-auth-key-seen
-  else
-    hostnamearg=""
-    if [[ -n "${CODESPACE_NAME}" ]]; then
-      hostnamearg="--hostname=${CODESPACE_NAME}"
-    fi
-    /usr/local/bin/tailscale up --accept-routes --authkey="$auth_key" $hostnamearg
-  fi
-fi

--- a/test/tailscale/tailscale_auth_key.sh
+++ b/test/tailscale/tailscale_auth_key.sh
@@ -7,7 +7,15 @@ set -e
 
 source dev-container-features-test-lib
 
-# Wait for the auth key to be seen by the start script.
+# The auth logic now runs in postCreateCommand, not entrypoint
+# So we need to manually trigger it for testing
+if [[ -f /usr/local/sbin/tailscaled-auth-setup ]]; then
+    # Run the auth setup script directly since test framework
+    # doesn't execute postCreateCommand
+    TS_AUTH_KEY="test-auth-key" /usr/local/sbin/tailscaled-auth-setup || true
+fi
+
+# Wait for the auth key to be seen by the auth setup script.
 count=100
 while ((count--)); do
     [[ -f /tmp/test-auth-key-seen ]] && break
@@ -16,7 +24,7 @@ done
 
 check "/tmp/test-auth-key-seen" ls /tmp/test-auth-key-seen
 
-# It would be nice to directly test that the entrypoint is doing unset
-# TS_AUTH_KEY, however that isn't visible to the test execution.
+# Verify the auth setup script exists
+check "tailscaled-auth-setup exists" ls /usr/local/sbin/tailscaled-auth-setup
 
 reportResults

--- a/test/tailscale/test.sh
+++ b/test/tailscale/test.sh
@@ -13,4 +13,7 @@ if [[ -n "$VERSION" ]]; then
     check "version is correct" bash -c "tailscale version --daemon | grep -q $VERSION"
 fi
 
+# Verify auth setup script is installed
+check "auth setup script exists" ls /usr/local/sbin/tailscaled-auth-setup
+
 reportResults


### PR DESCRIPTION
The devcontainer  was failing to authenticate automatically with `TS_AUTH_KEY` when env var was setup. The root cause was a timing issue:

- Build Phase: Feature installs and entrypoint runs (secrets NOT available)
- Runtime Phase: GitHub Codespaces injects secrets (too late for entrypoint)

This meant `TS_AUTH_KEY` was undefined when the authentication logic ran.
Changes
- Added `postCreateCommand` to run auth script
- Removed auth logic from entrypoint 
- Created new script for authentication

fixes: #53 